### PR TITLE
Remove deprecated tilde syntax for sass imports

### DIFF
--- a/scss/01-tools/mixins/_breakpoint.scss
+++ b/scss/01-tools/mixins/_breakpoint.scss
@@ -5,7 +5,7 @@
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
-@use '~sass-mq/mq' as * with (
+@use 'sass-mq/mq' as * with (
   $breakpoints: $mq-breakpoints
 );
 

--- a/scss/01-tools/mixins/_fluid-calc.scss
+++ b/scss/01-tools/mixins/_fluid-calc.scss
@@ -5,7 +5,7 @@
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:meta';
-@use '~sass-mq/mq' as *;
+@use 'sass-mq/mq' as *;
 
 /// Generate min, max and fluid in-between values for a given CSS property
 ///

--- a/test/loop-variation.spec.scss
+++ b/test/loop-variation.spec.scss
@@ -1,4 +1,4 @@
-@use 'true' as *;
+@use 'sass-true' as *;
 
 // stylelint-disable length-zero-no-unit
 $mq-breakpoints: (

--- a/test/modular-scale-config.spec.scss
+++ b/test/modular-scale-config.spec.scss
@@ -1,4 +1,4 @@
-@use 'true' as *;
+@use 'sass-true' as *;
 
 // stylelint-disable length-zero-no-unit
 $mq-breakpoints: (

--- a/test/scss.spec.js
+++ b/test/scss.spec.js
@@ -1,10 +1,11 @@
 const path = require('path');
+const fs = require('fs');
 const sassTrue = require('sass-true');
 const glob = require('glob');
 
 function importer(url) {
-  if (url[0] === '~') {
-    url = path.resolve('node_modules', url.substr(1));
+  if (!fs.existsSync(url)) {
+    url = path.resolve('node_modules', url);
   }
 
   return { file: url };


### PR DESCRIPTION
From [webpack docs](https://webpack.js.org/loaders/sass-loader/#resolving-import-at-rules):

> Using ~ is deprecated and can be removed from your code (we recommend it), but we still support it for historical reasons. Why can you remove it? The loader will first try to resolve @import as a relative path. If it cannot be resolved, then the loader will try to resolve @import inside [node_modules](https://webpack.js.org/configuration/resolve/#resolvemodules).